### PR TITLE
Ask subscribers to sign a signature

### DIFF
--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -89,6 +89,8 @@ async function ensureSubsciberSignatureIsSigned(provider) {
     signature = await signer.signMessage(SUBSCRIBER_SIGNATURE_MESSAGE);
     localStorage.setItem('subscriberSignature', signature);
   }
+
+  return signature;
 }
 
 function getExpectedChain() {
@@ -117,7 +119,9 @@ function App() {
 
   useEffect(() => {
     if (subscriber) {
-      setSubscriberSignature(ensureSubsciberSignatureIsSigned(provider));
+      ensureSubsciberSignatureIsSigned(provider).then((generatedSignature) => {
+        setSubscriberSignature(generatedSignature);
+      });
     }
   }, [subscriber, setSubscriberSignature, provider]);
 


### PR DESCRIPTION
If a subscriber does not have a signature stored in the local storage, ask to sign a message, and store it in local storage.